### PR TITLE
fix: Update promo_div class name and improve robustness

### DIFF
--- a/scribd.com/content.js
+++ b/scribd.com/content.js
@@ -5,8 +5,10 @@ const revealPage = () => {
         try {
             // remove promo pop-up from page
 
-            let promo = page.querySelector('.auto__doc_page_webpack_doc_page_blur_promo');
-            promo.parentElement.removeChild(promo);
+            let promo = page.querySelector('.promo_div');
+            if (promo) {
+                promo.parentElement.removeChild(promo);
+            }
 
             // Search for blured text and set to normal
 


### PR DESCRIPTION
The old code would completely fail if the promo pop-up had changed class name. Now it should complete the other fixes as usual and just ignore the missing div. The others were already robust since they use an array, which would just be empty if it wasn't found.

I also updated the selector to the new name of the promo div. 

I haven't tested the full extension, but copy-pasting the main function into the js console unblurs the page as it should now.